### PR TITLE
大佬，发现您的项目引入了org.springframework.security:spring-security-core@4.2.6.RELEASE组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>onlineShop_1</groupId>
 	<artifactId>onlineShop_1</artifactId>
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
-			<version>4.2.6.RELEASE</version>
+			<version>5.2.9.RELEASE</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-config -->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Vmware VMware Spring Security 权限许可和访问控制问题漏洞
缺陷组件：org.springframework.security:spring-security-core@4.2.6.RELEASE
漏洞编号：CVE-2021-22112
漏洞描述：Vmware VMware Spring Security是美国威睿（Vmware）公司的一套为基于Spring的应用程序提供说明性安全保护的安全框架。
VMware Spring Security 中存在权限许可和访问控制问题漏洞。该漏洞源于攻击者可以通过Spring Security的多个SecurityContext更改绕过限制，以提升其权限。以下产品及版本受到影响：Spring Security 5.4.0 至 5.4.3 版本, Spring Security 5.3.0.RELEASE 至 5.3.7.RELEASE 版本, Spring Security 5.2.0.RELEASE 至 5.2.8.RELEASE 版本。
影响范围：(∞, 5.2.9.RELEASE)
最小修复版本：5.2.9.RELEASE
缺陷组件引入路径：onlineShop_1:onlineShop_1@1.0->org.springframework.security:spring-security-core@4.2.6.RELEASE
```
另外我运行这个项目时，IDE的安全插件提示还有83个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p23a91